### PR TITLE
Add tkinter interface handler with item management

### DIFF
--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -1,4 +1,3 @@
-import __main__
 from os.path import join, dirname
 from helpers.tupleHelper import twoDTruncate
 from helpers.conversionHelper import toRGBA
@@ -7,7 +6,7 @@ from helpers.conversionHelper import toRGBA
 # =============
 # = CONSTANT
 # =============
-SRC = dirname(getattr(__main__, '__file__', ""))
+SRC = dirname(dirname(__file__))
 ROOT = dirname(SRC)
 
 # = Card =

--- a/src/handlers/__init__.py
+++ b/src/handlers/__init__.py
@@ -1,0 +1,2 @@
+from .interfaceHandler import InterfaceHandler
+

--- a/src/handlers/interfaceHandler.py
+++ b/src/handlers/interfaceHandler.py
@@ -1,0 +1,175 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+from typing import List
+from os.path import join
+from PIL import Image, ImageTk
+
+from classes.types import Item, DamageType, AttributeType
+from config.constants import ITEM_IMAGES_PATH, IMAGE_FORMAT, OUTPUT_PATH
+from helpers.dataHelper import getItems, addItem
+from handlers.imageHandler import ImageHandler
+
+
+class InterfaceHandler:
+    def __init__(self) -> None:
+        self.root = tk.Tk()
+        self.root.title("DHelper")
+        self.image_handler = ImageHandler()
+        self._build_main_menu()
+
+    def _clear_root(self) -> None:
+        for child in self.root.winfo_children():
+            child.destroy()
+
+    def _build_main_menu(self) -> None:
+        self._clear_root()
+        frame = ttk.Frame(self.root, padding=20)
+        frame.pack(fill="both", expand=True)
+        ttk.Button(frame, text="Items", command=self._open_items_menu, width=30).pack(pady=10)
+        ttk.Button(frame, text="Spells", command=self._open_spells_menu, width=30).pack(pady=10)
+
+    def _open_items_menu(self) -> None:
+        self._clear_root()
+        frame = ttk.Frame(self.root, padding=20)
+        frame.pack(fill="both", expand=True)
+        ttk.Button(frame, text="Add Item", command=self._open_add_item).pack(pady=5, fill="x")
+        ttk.Button(frame, text="Print Items", command=self._open_print_items).pack(pady=5, fill="x")
+        ttk.Button(frame, text="Back", command=self._build_main_menu).pack(pady=10)
+
+    def _open_spells_menu(self) -> None:
+        self._clear_root()
+        frame = ttk.Frame(self.root, padding=20)
+        frame.pack(fill="both", expand=True)
+        ttk.Label(frame, text="Spells functionality not implemented yet").pack(pady=10)
+        ttk.Button(frame, text="Back", command=self._build_main_menu).pack(pady=10)
+
+    # ===== Add Item =====
+    def _open_add_item(self) -> None:
+        window = tk.Toplevel(self.root)
+        window.title("Add Item")
+
+        entries: dict[str, tk.Entry] = {}
+        row = 0
+        for label in ["ID", "Name", "Price", "Weight", "Damage Dice Amount", "Damage Dice Type", "Damage Bonus"]:
+            ttk.Label(window, text=label).grid(row=row, column=0, sticky="e", padx=5, pady=2)
+            entry = ttk.Entry(window)
+            entry.grid(row=row, column=1, padx=5, pady=2)
+            entries[label] = entry
+            row += 1
+
+        damage_types = list(DamageType.__args__)  # type: ignore
+        ttk.Label(window, text="Damage Type").grid(row=row, column=0, sticky="e", padx=5, pady=2)
+        dmg_type_var = tk.StringVar(value="")
+        ttk.Combobox(window, textvariable=dmg_type_var, values=[""] + damage_types, state="readonly").grid(row=row, column=1, padx=5, pady=2)
+        row += 1
+
+        attribute_types = list(AttributeType.__args__)  # type: ignore
+        attr_vars: List[tk.BooleanVar] = []
+        ttk.Label(window, text="Attributes").grid(row=row, column=0, sticky="ne", padx=5, pady=2)
+        attr_frame = ttk.Frame(window)
+        attr_frame.grid(row=row, column=1, sticky="w")
+        for at in attribute_types:
+            var = tk.BooleanVar(value=False)
+            chk = ttk.Checkbutton(attr_frame, text=at, variable=var)
+            chk.pack(anchor="w")
+            attr_vars.append(var)
+        row += 1
+
+        def submit() -> None:
+            try:
+                _id = entries["ID"].get().strip()
+                name = entries["Name"].get().strip()
+                price = float(entries["Price"].get()) if entries["Price"].get() else 0
+                weight = float(entries["Weight"].get()) if entries["Weight"].get() else 0
+                dmg_amount = int(entries["Damage Dice Amount"].get()) if entries["Damage Dice Amount"].get() else 0
+                dmg_type = int(entries["Damage Dice Type"].get()) if entries["Damage Dice Type"].get() else 1
+                dmg_bonus = int(entries["Damage Bonus"].get()) if entries["Damage Bonus"].get() else 0
+                damage_type = dmg_type_var.get() or None
+                attributes = [at for at, var in zip(attribute_types, attr_vars) if var.get()]
+            except ValueError as e:
+                messagebox.showerror("Error", f"Invalid value: {e}")
+                return
+            if not _id or not name:
+                messagebox.showerror("Error", "ID and Name are required")
+                return
+            item = Item(
+                _id=_id,
+                name=name,
+                price=price,
+                weight=weight,
+                damageDiceAmount=dmg_amount,
+                damageDiceType=dmg_type,
+                damageBonus=dmg_bonus,
+                damageType=damage_type,  # type: ignore
+                attributes=attributes,
+            )
+            addItem(item)
+            messagebox.showinfo("Saved", "Item saved")
+            window.destroy()
+
+        ttk.Button(window, text="Add", command=submit).grid(row=row, column=0, columnspan=2, pady=10)
+
+    # ===== Print Items =====
+    def _open_print_items(self) -> None:
+        items = getItems()
+        if not items:
+            messagebox.showinfo("No Items", "No items found")
+            return
+        PreviewWindow(self.root, items, self.image_handler)
+
+    def run(self) -> None:
+        self.root.mainloop()
+
+
+class PreviewWindow(tk.Toplevel):
+    def __init__(self, root: tk.Tk, items: List[Item], image_handler: ImageHandler) -> None:
+        super().__init__(root)
+        self.title("Item Preview")
+        self.items = items
+        self.index = 0
+        self.image_handler = image_handler
+        self.label = ttk.Label(self)
+        self.label.pack(padx=10, pady=10)
+
+        btn_frame = ttk.Frame(self)
+        btn_frame.pack()
+        ttk.Button(btn_frame, text="Rotate", command=self._rotate).pack(side="left", padx=2)
+        ttk.Button(btn_frame, text="Flip", command=self._flip).pack(side="left", padx=2)
+        ttk.Button(btn_frame, text="Next", command=self._next).pack(side="left", padx=2)
+
+        self.original: Image.Image | None = None
+        self.display: Image.Image | None = None
+        self.tk_img: ImageTk.PhotoImage | None = None
+        self._load_current()
+
+    def _load_current(self) -> None:
+        item = self.items[self.index]
+        self.image_handler.createItemCard(item)
+        path = join(OUTPUT_PATH, f"{item.id}.png")
+        self.original = Image.open(path)
+        self.display = self.original
+        self._update_image()
+
+    def _update_image(self) -> None:
+        if self.display is None:
+            return
+        self.tk_img = ImageTk.PhotoImage(self.display)
+        self.label.configure(image=self.tk_img)
+
+    def _rotate(self) -> None:
+        if self.display:
+            self.display = self.display.rotate(90, expand=True)
+            self._update_image()
+
+    def _flip(self) -> None:
+        if self.display:
+            self.display = self.display.transpose(Image.FLIP_LEFT_RIGHT)
+            self._update_image()
+
+    def _next(self) -> None:
+        self.index += 1
+        if self.index >= len(self.items):
+            self.destroy()
+            return
+        self._load_current()
+

--- a/src/helpers/dataHelper.py
+++ b/src/helpers/dataHelper.py
@@ -1,13 +1,20 @@
 import json
+from json import load, dump
 from classes.types import Item, JsonItem
 from config.constants import ITEMS_LIST_PATH
-from json import load
 from helpers.conversionHelper import toItem
+
 
 def getItems() -> list[Item]:
     with open(ITEMS_LIST_PATH, "r", encoding="utf-8") as file:
         jsonItems: dict[str, JsonItem] = load(file)
-    items: list[Item] = [
-        toItem(_id=key,  jsonItem=item) for key, item in jsonItems.items()
-    ]
+    items: list[Item] = [toItem(_id=key, jsonItem=item) for key, item in jsonItems.items()]
     return items
+
+
+def addItem(item: Item) -> None:
+    with open(ITEMS_LIST_PATH, "r", encoding="utf-8") as file:
+        data: dict[str, JsonItem] = load(file)
+    data[item.id] = item.toJsonItem()
+    with open(ITEMS_LIST_PATH, "w", encoding="utf-8") as file:
+        dump(data, file, ensure_ascii=False, indent=4)

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,11 @@
-from handlers.imageHandler import ImageHandler
+from handlers.interfaceHandler import InterfaceHandler
+
+
 def main() -> None:
-    I = ImageHandler()
-    I.createItemCards()
+    app = InterfaceHandler()
+    app.run()
+
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- add a new Tkinter based `InterfaceHandler` for interactive menus
- support adding new items and previewing existing ones
- save new items in JSON via `addItem`
- update constants path logic and entry point in `main`

## Testing
- `python3 test_data_encoding.py`

------
https://chatgpt.com/codex/tasks/task_e_6884d2ce9b04832a9ea48af37b3eb7ba