### PR TITLE
Improve item entry form and dark theme

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -34,5 +34,32 @@
                 18
             ]
         }
+    },
+    "speer": {
+        "name": "Speer",
+        "price": 1,
+        "weight": 1,
+        "damage": {
+            "diceAmount": 1,
+            "diceType": 6,
+            "bonus": 0,
+            "damageType": "Stich"
+        },
+        "versatileDamage": {
+            "diceAmount": 1,
+            "diceType": 8,
+            "bonus": 0,
+            "damageType": "Stich"
+        },
+        "attributes": [
+            "Wurfwaffe",
+            "Vielseitig"
+        ],
+        "ranges": {
+            "Wurfwaffe": [
+                6,
+                18
+            ]
+        }
     }
 }

--- a/src/classes/types.py
+++ b/src/classes/types.py
@@ -34,6 +34,7 @@ class JsonItem(TypedDict, total=False):
     price: int
     weight: float
     damage: JsonDamage | None
+    versatileDamage: JsonDamage | None
     attributes: list[AttributeType]
     ranges: dict[str, list[int]]
 
@@ -79,12 +80,14 @@ class Item:
         damageType: Optional[DamageType] = None,
         attributes: Optional[list[AttributeType]] = None,
         ranges: Optional[dict[str, tuple[int, int]]] = None,
+        versatileDamage: Optional[Damage] = None,
     ) -> None:
         self.id: str = _id
         self.name: str = name
         self.price: int = price
         self.weight: float = weight
         self.damage = Damage(damageDiceAmount, damageDiceType, damageBonus, damageType) if damageType is not None else None
+        self.versatileDamage: Optional[Damage] = versatileDamage
         self.attributes: list[AttributeType] = attributes if attributes else []
         self.ranges: dict[str, tuple[int, int]] = ranges if ranges else {}
     def toJsonItem(self) -> JsonItem:
@@ -93,6 +96,7 @@ class Item:
             "price": self.price,
             "weight": self.weight,
             "damage": self.damage.toJsonDamage() if self.damage else None,
+            "versatileDamage": self.versatileDamage.toJsonDamage() if self.versatileDamage else None,
             "attributes": self.attributes,
             **({"ranges": {k: [v[0], v[1]] for k, v in self.ranges.items()}} if self.ranges else {})
         }  # type: ignore

--- a/src/helpers/conversionHelper.py
+++ b/src/helpers/conversionHelper.py
@@ -1,10 +1,12 @@
-from classes.types import RGB, JsonItem, Item, HexColor, RGBA
+from classes.types import RGB, JsonItem, Item, HexColor, RGBA, Damage
 def toItem(_id: str, jsonItem: JsonItem) -> Item:
     ranges = {
         k: (int(v[0]), int(v[1])) if isinstance(v, (list, tuple)) and len(v) >= 2 else (0, 0)
         for k, v in jsonItem.get("ranges", {}).items()
     }
     damage = jsonItem.get("damage")
+    versatile = jsonItem.get("versatileDamage")
+    primary_type = damage.get("damageType", "") if isinstance(damage, dict) else ""
     return Item(
         _id=_id,
         name=jsonItem.get("name", ""),
@@ -21,6 +23,16 @@ def toItem(_id: str, jsonItem: JsonItem) -> Item:
             }
             if damage
             else {}
+        ),
+        versatileDamage=(
+            Damage(
+                versatile.get("diceAmount", 0),
+                versatile.get("diceType", 1),
+                versatile.get("bonus", 0),
+                versatile.get("damageType", primary_type),
+            )
+            if versatile
+            else None
         ),
     )
 


### PR DESCRIPTION
## Summary
- style entries and comboboxes with a dark background so text is readable
- show versatile damage inputs only when "Vielseitig" is selected
- combine damage inputs into a single row with dice amount, dice type, bonus and damage type selectors

## Testing
- `python test_data_encoding.py`


------
https://chatgpt.com/codex/tasks/task_e_6884ddb8bba8832ab0194c9500aef81c