### PR TITLE
Refine spell card helpers

### DIFF
--- a/src/handlers/interfaceHandler.py
+++ b/src/handlers/interfaceHandler.py
@@ -81,10 +81,18 @@ class InterfaceHandler:
 
     def _open_spells_menu(self) -> None:
         self._clear_root()
-        frame = ttk.Frame(self.root, padding=20)
-        frame.pack(fill="both", expand=True)
-        ttk.Label(frame, text=translate(UIText.SPELLS_NOT_IMPLEMENTED)).pack(pady=10)
-        ttk.Button(frame, text=translate(UIText.BUTTON_BACK), command=self._build_main_menu).pack(pady=10)
+        try:
+            self.image_handler.createSpellCards()
+            messagebox.showinfo(
+                translate(MessageText.DONE_TITLE),
+                translate(MessageText.DONE_MESSAGE),
+            )
+        except Exception as e:
+            messagebox.showerror(
+                translate(MessageText.ERROR_TITLE),
+                str(e),
+            )
+        self._build_main_menu()
 
     # ===== Manage Items =====
     def _open_manage_items(self) -> None:

--- a/src/helpers/conversionHelper.py
+++ b/src/helpers/conversionHelper.py
@@ -1,4 +1,23 @@
-from classes.types import RGB, JsonItem, Item, HexColor, RGBA, Damage, DamageType, AttributeType
+from datetime import timedelta
+from classes.types import (
+    RGB,
+    JsonItem,
+    Item,
+    HexColor,
+    RGBA,
+    Damage,
+    DamageType,
+    AttributeType,
+    Spell,
+    JsonSpell,
+    SpellType,
+    CasterClassType,
+    Components,
+    Material,
+    CastingTimeType,
+    TargetType,
+    SavingThrowType,
+)
 from helpers.translationHelper import to_enum
 def toItem(_id: str, jsonItem: JsonItem) -> Item:
     ranges = {
@@ -40,6 +59,49 @@ def toItem(_id: str, jsonItem: JsonItem) -> Item:
             if versatile
             else None
         ),
+    )
+
+def toSpell(_id: str, jsonSpell: JsonSpell) -> Spell:
+    comps = jsonSpell.get("components", {})
+    mat = comps.get("material")
+    material = None
+    if isinstance(mat, dict):
+        material = Material(mat.get("name", ""), mat.get("cost"))
+    components = Components(
+        comps.get("verbal", False),
+        comps.get("gestural", False),
+        material,
+    )
+    dmg = jsonSpell.get("damage")
+    damage = (
+        Damage(
+            dmg.get("diceAmount", 0),
+            dmg.get("diceType", 1),
+            dmg.get("bonus", 0),
+            to_enum(DamageType, dmg.get("damageType")) if dmg.get("damageType") else DamageType.SLASHING,
+        )
+        if isinstance(dmg, dict)
+        else None
+    )
+    return Spell(
+        id=_id,
+        name=jsonSpell.get("name", ""),
+        level=int(jsonSpell.get("level", 1)),
+        type=to_enum(SpellType, jsonSpell.get("type", "")),
+        casterClass=to_enum(CasterClassType, jsonSpell.get("casterClass", "")),
+        duration=timedelta(seconds=float(jsonSpell.get("duration", 0))),
+        cooldown=timedelta(seconds=float(jsonSpell.get("cooldown", 0))),
+        range=float(jsonSpell.get("range", 0)),
+        subRange=jsonSpell.get("subRange"),
+        damage=damage,
+        components=components,
+        levelBonus=jsonSpell.get("levelBonus", ""),
+        castingTime=to_enum(CastingTimeType, jsonSpell.get("castingTime", "ACTION")),
+        ritual=bool(jsonSpell.get("ritual", False)),
+        concentration=bool(jsonSpell.get("concentration", False)),
+        target=to_enum(TargetType, jsonSpell.get("target", "SELF")),
+        savingThrow=to_enum(SavingThrowType, jsonSpell.get("savingThrow")) if jsonSpell.get("savingThrow") else None,
+        areaOfEffect=to_enum(TargetType, jsonSpell.get("areaOfEffect")) if jsonSpell.get("areaOfEffect") else None,
     )
 
 def toRGBA(hex: HexColor) -> RGBA:

--- a/src/helpers/dataHelper.py
+++ b/src/helpers/dataHelper.py
@@ -1,9 +1,15 @@
 import json
 from json import load, dump
-from classes.types import Item, JsonItem, JsonItemCache
+from classes.types import (
+    Item,
+    JsonItem,
+    JsonItemCache,
+    Spell,
+    JsonSpell,
+)
 from config.constants import DATA, PATHS
 import os
-from helpers.conversionHelper import toItem
+from helpers.conversionHelper import toItem, toSpell
 
 
 def getItems() -> list[Item]:
@@ -41,3 +47,9 @@ def updateItemCache(item_id: str, rotate: float, scale: float, flip: bool) -> No
     cache = loadItemCache()
     cache[item_id] = {"rotate": rotate, "scale": scale, "flip": flip}
     saveItemCache(cache)
+
+
+def getSpells() -> list[Spell]:
+    with open(DATA.SPELLS, "r", encoding="utf-8") as file:
+        jsonSpells: dict[str, JsonSpell] = load(file)
+    return [toSpell(key, value) for key, value in jsonSpells.items()]

--- a/src/helpers/formattingHelper.py
+++ b/src/helpers/formattingHelper.py
@@ -1,4 +1,7 @@
+from datetime import timedelta
 from PIL import ImageFont, ImageDraw, Image
+from classes.types import Damage
+
 
 def getMaxFontSize(text: str, fontPath: str, maxSize: int, maxWidth: float, maxHeight: float = float("inf")) -> int:
     size = maxSize
@@ -12,6 +15,7 @@ def getMaxFontSize(text: str, fontPath: str, maxSize: int, maxWidth: float, maxH
         if testWidth < maxWidth and testHeight < maxHeight:
             break
     return size
+
 
 def findOptimalAttributeLayout(attributes: list[str], fixedRows: list[str], fontPath: str, maxFontSize: int, maxWidth: float, maxHeight: float) -> tuple[list[str], int]:
     if not attributes:
@@ -65,3 +69,26 @@ def findOptimalAttributeLayout(attributes: list[str], fixedRows: list[str], font
                     bestLayout = testRows
 
     return bestLayout, bestFontSize
+
+
+def formatDamage(d: Damage, withType: bool = False) -> str:
+    """Return a formatted damage string."""
+    diceStr = f"{d.diceAmount}D{d.diceType}" if d.diceAmount > 0 else ""
+    bonusStr = "" if d.bonus == 0 else str(d.bonus) if not diceStr else f" {'+' if d.bonus > 0 else ''}{d.bonus}"
+    result = f"{diceStr}{bonusStr}"
+    if withType:
+        result = f"{result} {d.damageType}".strip()
+    return result
+
+
+def formatTimedelta(delta: timedelta) -> str:
+    """Return a human readable representation of a timedelta."""
+    total = int(delta.total_seconds())
+    hours = total // 3600
+    minutes = (total % 3600) // 60
+    seconds = total % 60
+    if hours:
+        return f"{hours}:{minutes:02d}:{seconds:02d}"
+    if minutes:
+        return f"{minutes}:{seconds:02d}"
+    return f"{seconds}s"


### PR DESCRIPTION
## Summary
- rename damage/time helpers to camelCase
- update spell card generation to use camelCase helpers
- adjust spell card drawing helpers to camelCase naming

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68855783f6f4832aae88955372488fc8