### PR TITLE
Improve spell handling and card layout

### DIFF
--- a/data/spells.json
+++ b/data/spells.json
@@ -4,7 +4,7 @@
         "name": "Feuerball",
         "level": 3,
         "type": "EVOCATION",
-        "casterClass": "WIZARD",
+        "casterClasses": ["WIZARD"],
         "duration": 1.0,
         "cooldown": 0.0,
         "range": 45.0,

--- a/src/classes/types.py
+++ b/src/classes/types.py
@@ -151,7 +151,7 @@ class JsonSpell(TypedDict):
     name: str
     level: int
     type: str
-    casterClass: str
+    casterClasses: list[str]
     duration: float # in seconds
     cooldown: float # in seconds
     range: float
@@ -255,12 +255,32 @@ class Item:
         }  # type: ignore
 
 class Spell:
-    def __init__(self, id: str, name: str, level: int, type: SpellType, casterClass: CasterClassType, duration: timedelta, cooldown: timedelta, range: float, castingTime: CastingTimeType, ritual: bool, concentration: bool, target: TargetType, subRange: Optional[float] = None, damage: Optional[Damage] = None, components: Components = Components(False, False, None), levelBonus: str = "", savingThrow: Optional[SavingThrowType] = None, areaOfEffect: Optional[TargetType] = None) -> None:
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        level: int,
+        type: SpellType,
+        casterClasses: list[CasterClassType],
+        duration: timedelta,
+        cooldown: timedelta,
+        range: float,
+        castingTime: CastingTimeType,
+        ritual: bool,
+        concentration: bool,
+        target: TargetType,
+        subRange: Optional[float] = None,
+        damage: Optional[Damage] = None,
+        components: Components = Components(False, False, None),
+        levelBonus: str = "",
+        savingThrow: Optional[SavingThrowType] = None,
+        areaOfEffect: Optional[TargetType] = None,
+    ) -> None:
         self.id: str = id
         self.name: str = name
         self.level: int = level
         self.type: SpellType = type
-        self.casterClass: CasterClassType = casterClass
+        self.casterClasses: list[CasterClassType] = casterClasses
         self.duration: timedelta = duration
         self.cooldown: timedelta = cooldown
         self.range: float = range
@@ -281,7 +301,7 @@ class Spell:
             "name": self.name,
             "level": self.level,
             "type": self.type.value,
-            "casterClass": self.casterClass.value,
+            "casterClasses": [c.value for c in self.casterClasses],
             "duration": self.duration.total_seconds(),
             "cooldown": self.cooldown.total_seconds(),
             "range": self.range,

--- a/src/handlers/imageHandler.py
+++ b/src/handlers/imageHandler.py
@@ -153,10 +153,16 @@ class ImageHandler:
             self.createItemCard(item)
 
     def createSpellCard(self, spell: Spell) -> None:
-        def addIcon(background: Image.Image, path: str, layout) -> None:
+        def addIcon(background: Image.Image, path: str, layout, center: bool = False) -> None:
             icon = Image.open(path).convert("RGBA")
             icon = icon.resize(layout.SIZE.ABSOLUTE, Resampling.LANCZOS)
-            background.paste(icon, layout.POSITION.ABSOLUTE, mask=icon)
+            pos = layout.POSITION.ABSOLUTE
+            if center:
+                pos = (
+                    pos[0] - layout.SIZE.ABSOLUTE[0] // 2,
+                    pos[1] - layout.SIZE.ABSOLUTE[1] // 2,
+                )
+            background.paste(icon, pos, mask=icon)
 
         def addText(background: Image.Image, text: str, layout, fontPath: str, maxSize: int) -> None:
             draw = ImageDraw.Draw(background)
@@ -187,7 +193,7 @@ class ImageHandler:
             9: IMAGE.ICONS.LEVELS.LEVEL_9,
         }
         levelIcon = levelIcons.get(spell.level, IMAGE.ICONS.LEVELS.LEVEL_1)
-        addIcon(card, levelIcon, SPELL.LEVEL)
+        addIcon(card, levelIcon, SPELL.LEVEL, center=True)
 
         addText(card, spell.name, SPELL.TITLE, FONT.TITLE_PATH, FONT_STYLE.SIZES.TITLE)
         addText(card, str(spell.type), SPELL.CATEGORY, FONT.TITLE_PATH, FONT_STYLE.SIZES.TITLE)
@@ -210,10 +216,10 @@ class ImageHandler:
         )
         addIcon(card, IMAGE.ICONS.DAMAGE, SPELL.DAMAGE)
         if spell.damage:
-            dmg_text = formatDamage(spell.damage, True)
+            dmg_text = f"{formatDamage(spell.damage)}\n{spell.damage.damageType}"
             addText(card, dmg_text, SPELL.DAMAGE_TEXT, FONT.STATS_PATH, FONT_STYLE.SIZES.STATS)
         addIcon(card, IMAGE.ICONS.RANGE, SPELL.RANGE)
-        addText(card, str(int(spell.range)), SPELL.RANGE_TEXT, FONT.STATS_PATH, FONT_STYLE.SIZES.STATS)
+        addText(card, f"{int(spell.range)}m", SPELL.RANGE_TEXT, FONT.STATS_PATH, FONT_STYLE.SIZES.STATS)
 
         # Components
         addIcon(card, IMAGE.ICONS.SPOKEN, SPELL.MATERIAL.SPOKEN)
@@ -244,7 +250,7 @@ class ImageHandler:
             addText(card, str(spell.savingThrow)[:3].upper(), SPELL.SAVING_THROW, FONT.STATS_PATH, FONT_STYLE.SIZES.STATS)
 
         if spell.subRange is not None:
-            addText(card, str(int(spell.subRange)), SPELL.SUB_RANGE, FONT.STATS_PATH, FONT_STYLE.SIZES.STATS)
+            addText(card, f"{int(spell.subRange)}m", SPELL.SUB_RANGE, FONT.STATS_PATH, FONT_STYLE.SIZES.STATS)
         targetIcons = {
             TargetType.CONE: IMAGE.ICONS.TARGETS.CONE,
             TargetType.CREATURE: IMAGE.ICONS.TARGETS.CREATURE,

--- a/src/helpers/conversionHelper.py
+++ b/src/helpers/conversionHelper.py
@@ -88,7 +88,10 @@ def toSpell(_id: str, jsonSpell: JsonSpell) -> Spell:
         name=jsonSpell.get("name", ""),
         level=int(jsonSpell.get("level", 1)),
         type=to_enum(SpellType, jsonSpell.get("type", "")),
-        casterClass=to_enum(CasterClassType, jsonSpell.get("casterClass", "")),
+        casterClasses=[
+            to_enum(CasterClassType, c)
+            for c in jsonSpell.get("casterClasses", [])
+        ],
         duration=timedelta(seconds=float(jsonSpell.get("duration", 0))),
         cooldown=timedelta(seconds=float(jsonSpell.get("cooldown", 0))),
         range=float(jsonSpell.get("range", 0)),


### PR DESCRIPTION
## Summary
- allow multiple caster classes for spells
- enable selecting components, sub range and level bonus in UI
- center level icon and icon text on spell cards
- show damage type on a new line and append measurement units

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_688616644aa4832a843b360c2df011b2