### PR TITLE
Improve spell preview and output handling

### DIFF
--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -129,9 +129,13 @@ DATA = _DataPaths()
 # = Output & Cache Paths =
 class _PathConstants:
     def __init__(self) -> None:
-        self.OUTPUT: str = join(ROOT, "output")
+        output = join(ROOT, "output")
+        self.OUTPUT: str = output
+        self.ITEM_OUTPUT: str = join(output, "items")
+        self.SPELL_OUTPUT: str = join(output, "spells")
         self.CACHE: str = join(ROOT, "cache")
-        self.ITEM_CACHE: str = join(ROOT, "cache", "itemCache.json")
+        self.ITEM_CACHE: str = join(self.CACHE, "itemCache.json")
+        self.SPELL_CACHE: str = join(self.CACHE, "spellCache.json")
 
 PATHS = _PathConstants()
 

--- a/src/helpers/dataHelper.py
+++ b/src/helpers/dataHelper.py
@@ -61,3 +61,25 @@ def addSpell(spell: Spell) -> None:
     data[spell.id] = spell.toJsonSpell()
     with open(DATA.SPELLS, "w", encoding="utf-8") as file:
         dump(data, file, ensure_ascii=False, indent=4)
+
+
+def loadSpellCache() -> dict[str, JsonItemCache]:
+    if not os.path.exists(PATHS.SPELL_CACHE):
+        os.makedirs(PATHS.CACHE, exist_ok=True)
+        with open(PATHS.SPELL_CACHE, "w", encoding="utf-8") as file:
+            dump({}, file)
+        return {}
+    with open(PATHS.SPELL_CACHE, "r", encoding="utf-8") as file:
+        return json.load(file)
+
+
+def saveSpellCache(cache: dict[str, JsonItemCache]) -> None:
+    os.makedirs(PATHS.CACHE, exist_ok=True)
+    with open(PATHS.SPELL_CACHE, "w", encoding="utf-8") as file:
+        dump(cache, file, ensure_ascii=False, indent=4)
+
+
+def updateSpellCache(spell_id: str, rotate: float, scale: float, flip: bool) -> None:
+    cache = loadSpellCache()
+    cache[spell_id] = {"rotate": rotate, "scale": scale, "flip": flip}
+    saveSpellCache(cache)


### PR DESCRIPTION
## Summary
- add dedicated output folders for items and spells
- store orientation settings for spell images
- generate spell cards with rotation and scaling
- preview spell cards in a new SpellPreviewWindow
- darken combobox dropdowns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68861f6f8e08832aa0c55ad4970672ec