### PR TITLE
Add image position sliders and modern theme

### DIFF
--- a/src/classes/types.py
+++ b/src/classes/types.py
@@ -170,6 +170,8 @@ class JsonItemCache(TypedDict):
     rotate: float
     scale: float
     flip: bool
+    offset_x: float
+    offset_y: float
 
 
 # ==========

--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -51,6 +51,8 @@ class _ImagePaths:
         self.ITEMS: str = join(assets, "items")
         self.SPELLS: str = join(assets, "spells")
         self.BACKGROUND: str = join(assets, "background")
+        # icon used for application windows
+        self.APP_ICON: str = join(self.SPELLS, "feuerball.png")
 
 class _BackgroundImages:
     def __init__(self) -> None:

--- a/src/handlers/imageHandler.py
+++ b/src/handlers/imageHandler.py
@@ -29,6 +29,8 @@ class ImageHandler:
         rotate: float = 0,
         flip: bool = False,
         scale: float = 1.0,
+        offset_x: float = 0.0,
+        offset_y: float = 0.0,
     ) -> None:
         def getCurrency(price: float) -> Currency:
             if price % 1 == 0:
@@ -48,7 +50,15 @@ class ImageHandler:
                     backgroundPath = IMAGE.BACKGROUNDS.SILVER_ITEM
             return Image.open(backgroundPath).convert("RGBA")
 
-        def addImage(background: Image.Image, id: str, rotate: float, flip: bool, scale: float) -> None:
+        def addImage(
+            background: Image.Image,
+            id: str,
+            rotate: float,
+            flip: bool,
+            scale: float,
+            offset_x: float,
+            offset_y: float,
+        ) -> None:
             imagePath = join(IMAGE.PATHS.ITEMS, id)
             if not os.path.exists(f"{imagePath}.{IMAGE.FORMAT}"):
                 raise FileNotFoundError(imagePath)
@@ -66,6 +76,8 @@ class ImageHandler:
             imageX, imageY = twoDSub(
                 ITEM.IMAGE.POSITION.ABSOLUTE, twoDTruncate((width, height), (1 / 2, 1 / 2))
             )
+            imageX += int(offset_x)
+            imageY += int(offset_y)
             resized = image.resize((width, height), resample=Resampling.LANCZOS)
             background.paste(resized, (imageX, imageY), mask=resized)
 
@@ -138,7 +150,7 @@ class ImageHandler:
 
         currency = getCurrency(item.price)
         cardImage = createBackground(currency)
-        addImage(cardImage, item.id, rotate, flip, scale)
+        addImage(cardImage, item.id, rotate, flip, scale, offset_x, offset_y)
         addPrice(cardImage, item.price, currency)
         addTitle(cardImage, item.name)
         addStats(cardImage, item.weight, item.damage, item.versatileDamage, item.attributes, item.ranges)
@@ -158,6 +170,8 @@ class ImageHandler:
         rotate: float = 0.0,
         flip: bool = False,
         scale: float = 1.0,
+        offset_x: float = 0.0,
+        offset_y: float = 0.0,
     ) -> None:
         def addIcon(background: Image.Image, path: str, layout, center: bool = True) -> None:
             icon = Image.open(path).convert("RGBA")
@@ -187,7 +201,15 @@ class ImageHandler:
 
         card = Image.open(IMAGE.BACKGROUNDS.SPELL).convert("RGBA")
 
-        def addImage(background: Image.Image, id: str, rotate: float, flip: bool, scale: float) -> None:
+        def addImage(
+            background: Image.Image,
+            id: str,
+            rotate: float,
+            flip: bool,
+            scale: float,
+            offset_x: float,
+            offset_y: float,
+        ) -> None:
             imagePath = join(IMAGE.PATHS.SPELLS, id)
             if not os.path.exists(f"{imagePath}.{IMAGE.FORMAT}"):
                 raise FileNotFoundError(imagePath)
@@ -204,6 +226,8 @@ class ImageHandler:
             imageX, imageY = twoDSub(
                 SPELL.IMAGE.POSITION.ABSOLUTE, twoDTruncate((width, height), (1 / 2, 1 / 2))
             )
+            imageX += int(offset_x)
+            imageY += int(offset_y)
             resized = image.resize((width, height), resample=Resampling.LANCZOS)
             background.paste(resized, (imageX, imageY), mask=resized)
 
@@ -223,7 +247,7 @@ class ImageHandler:
 
         addText(card, spell.name, SPELL.TITLE, FONT.TITLE_PATH, FONT_STYLE.SIZES.TITLE)
         addText(card, str(spell.type), SPELL.CATEGORY, FONT.TITLE_PATH, FONT_STYLE.SIZES.TITLE)
-        addImage(card, spell.id, rotate, flip, scale)
+        addImage(card, spell.id, rotate, flip, scale, offset_x, offset_y)
 
         addIcon(card, IMAGE.ICONS.DURATION, SPELL.DURATION)
         addText(

--- a/src/handlers/interfaceHandler.py
+++ b/src/handlers/interfaceHandler.py
@@ -20,7 +20,7 @@ from classes.types import (
 )
 from classes.textKeys import UIText, MessageText
 from helpers.translationHelper import translate, to_enum
-from config.constants import GAME, PATHS
+from config.constants import GAME, PATHS, IMAGE
 from helpers.dataHelper import (
     getItems,
     addItem,
@@ -38,46 +38,54 @@ class InterfaceHandler:
     def __init__(self) -> None:
         self.root = tk.Tk()
         self.root.title(translate(UIText.APP_TITLE))
-        self._set_dark_theme()
+        self._set_icon(self.root)
+        self._set_modern_theme()
         self.image_handler = ImageHandler()
         self._build_main_menu()
 
-    def _set_dark_theme(self) -> None:
+    def _set_icon(self, window: tk.Toplevel | tk.Tk) -> None:
+        try:
+            icon = tk.PhotoImage(file=IMAGE.PATHS.APP_ICON)
+            window.iconphoto(True, icon)
+        except Exception:
+            pass
+
+    def _set_modern_theme(self) -> None:
         style = ttk.Style(self.root)
         try:
             style.theme_use("clam")
         except tk.TclError:
             pass
-        dark_bg = "#2b2b2b"
-        fg = "#f0f0f0"
-        style.configure(".", background=dark_bg, foreground=fg)
-        style.configure("TFrame", background=dark_bg)
-        style.configure("TLabel", background=dark_bg, foreground=fg)
-        style.configure("TCheckbutton", background=dark_bg, foreground=fg)
-        style.configure("TButton", background="#444", foreground=fg)
+        bg = "#f5f5f5"
+        fg = "#333333"
+        style.configure(".", background=bg, foreground=fg)
+        style.configure("TFrame", background=bg)
+        style.configure("TLabel", background=bg, foreground=fg)
+        style.configure("TCheckbutton", background=bg, foreground=fg)
+        style.configure("TButton", background="#e0e0e0", foreground=fg)
         style.configure(
             "TEntry",
-            fieldbackground="#444",
-            background="#444",
+            fieldbackground="#ffffff",
+            background="#ffffff",
             foreground=fg,
             insertcolor=fg,
         )
         style.configure(
             "TCombobox",
-            fieldbackground="#444",
-            background="#444",
+            fieldbackground="#ffffff",
+            background="#ffffff",
             foreground=fg,
-            selectbackground="#555",
+            selectbackground="#dddddd",
         )
-        self.root.option_add("*TCombobox*Listbox.background", "#444")
+        self.root.option_add("*TCombobox*Listbox.background", "#ffffff")
         self.root.option_add("*TCombobox*Listbox.foreground", fg)
-        self.root.option_add("*TCombobox*Listbox.selectBackground", "#555")
-        style.map("TButton", background=[("active", "#3a3a3a")])
-        style.map("TCheckbutton", background=[("active", "#3a3a3a")])
-        style.configure("Treeview", background="#444", foreground=fg, fieldbackground="#444")
-        style.configure("Treeview.Heading", background="#555", foreground=fg)
-        style.map("Treeview", background=[("selected", "#555")])
-        self.root.configure(bg=dark_bg)
+        self.root.option_add("*TCombobox*Listbox.selectBackground", "#dddddd")
+        style.map("TButton", background=[("active", "#cccccc")])
+        style.map("TCheckbutton", background=[("active", "#cccccc")])
+        style.configure("Treeview", background="#ffffff", foreground=fg, fieldbackground="#ffffff")
+        style.configure("Treeview.Heading", background="#e0e0e0", foreground=fg)
+        style.map("Treeview", background=[("selected", "#cccccc")])
+        self.root.configure(bg=bg)
 
     def _clear_root(self) -> None:
         for child in self.root.winfo_children():
@@ -111,6 +119,7 @@ class InterfaceHandler:
     # ===== Manage Items =====
     def _open_manage_items(self) -> None:
         window = tk.Toplevel(self.root)
+        self._set_icon(window)
         window.title(translate(UIText.MANAGE_ITEMS_TITLE))
         window.configure(bg=self.root["background"])
 
@@ -221,10 +230,13 @@ class InterfaceHandler:
                     rotate=t.get("rotate", 0.0),
                     flip=t.get("flip", False),
                     scale=t.get("scale", 1.0),
+                    offset_x=t.get("offset_x", 0.0),
+                    offset_y=t.get("offset_y", 0.0),
                 )
                 path = join(PATHS.ITEM_OUTPUT, f"{item.id}.png")
                 img = Image.open(path)
                 top = tk.Toplevel(window)
+                self._set_icon(top)
                 top.title(f"{item.name} Card")
                 tk_img = ImageTk.PhotoImage(img)
                 lbl = ttk.Label(top, image=tk_img)
@@ -267,6 +279,7 @@ class InterfaceHandler:
 
     # ===== Add Item =====
     def _item_form(self, window: tk.Toplevel, item: Item | None) -> None:
+        self._set_icon(window)
         window.configure(bg=self.root["background"])
 
         entries: dict[str, tk.Entry] = {}
@@ -450,6 +463,7 @@ class InterfaceHandler:
         ttk.Button(window, text=translate(UIText.SAVE_BUTTON), command=submit).grid(row=row, column=0, columnspan=2, pady=10)
 
     def _spell_form(self, window: tk.Toplevel, spell: Spell | None) -> None:
+        self._set_icon(window)
         window.configure(bg=self.root["background"])
 
         row = 0
@@ -679,27 +693,32 @@ class InterfaceHandler:
 
     def _open_add_item(self) -> None:
         window = tk.Toplevel(self.root)
+        self._set_icon(window)
         window.title(translate(UIText.ADD_ITEM_TITLE))
         self._item_form(window, None)
 
     def _open_edit_item(self, item: Item) -> None:
         window = tk.Toplevel(self.root)
+        self._set_icon(window)
         window.title(f"{translate(UIText.EDIT_ITEM_TITLE)}: {item.name}")
         self._item_form(window, item)
 
     # ===== Spells =====
     def _open_add_spell(self) -> None:
         window = tk.Toplevel(self.root)
+        self._set_icon(window)
         window.title(translate(UIText.ADD_SPELL_TITLE))
         self._spell_form(window, None)
 
     def _open_edit_spell(self, spell: Spell) -> None:
         window = tk.Toplevel(self.root)
+        self._set_icon(window)
         window.title(f"{translate(UIText.EDIT_SPELL_TITLE)}: {spell.name}")
         self._spell_form(window, spell)
 
     def _open_manage_spells(self) -> None:
         window = tk.Toplevel(self.root)
+        self._set_icon(window)
         window.title(translate(UIText.MANAGE_SPELLS_TITLE))
         window.configure(bg=self.root["background"])
 
@@ -761,10 +780,13 @@ class InterfaceHandler:
                     rotate=t.get("rotate", 0.0),
                     flip=t.get("flip", False),
                     scale=t.get("scale", 1.0),
+                    offset_x=t.get("offset_x", 0.0),
+                    offset_y=t.get("offset_y", 0.0),
                 )
                 path = join(PATHS.SPELL_OUTPUT, f"level{sp.level}", f"{sp.id}.png")
                 img = Image.open(path)
                 top = tk.Toplevel(window)
+                self._set_icon(top)
                 top.title(sp.name)
                 tk_img = ImageTk.PhotoImage(img)
                 lbl = ttk.Label(top, image=tk_img)
@@ -827,6 +849,8 @@ class InterfaceHandler:
                     rotate=t.get("rotate", 0.0),
                     flip=t.get("flip", False),
                     scale=t.get("scale", 1.0),
+                    offset_x=t.get("offset_x", 0.0),
+                    offset_y=t.get("offset_y", 0.0),
                 )
 
         if preview_spells:
@@ -886,6 +910,11 @@ class PreviewWindow(tk.Toplevel):
         cache: dict,
     ) -> None:
         super().__init__(root)
+        try:
+            icon = tk.PhotoImage(file=IMAGE.PATHS.APP_ICON)
+            self.iconphoto(True, icon)
+        except Exception:
+            pass
         self.title(translate(UIText.ITEM_PREVIEW_TITLE))
         self.configure(bg=root["background"])
         self.items = items
@@ -902,6 +931,10 @@ class PreviewWindow(tk.Toplevel):
         ttk.Scale(btn_frame, from_=-180, to=180, orient="horizontal", variable=self.angle_var, command=self._update_angle, length=150).pack(side="left", padx=2)
         self.scale_var = tk.DoubleVar(value=1.0)
         ttk.Scale(btn_frame, from_=0.5, to=1.5, orient="horizontal", variable=self.scale_var, command=self._update_scale, length=150).pack(side="left", padx=2)
+        self.x_var = tk.DoubleVar(value=0)
+        ttk.Scale(btn_frame, from_=-50, to=50, orient="horizontal", variable=self.x_var, command=self._update_offset, length=100).pack(side="left", padx=2)
+        self.y_var = tk.DoubleVar(value=0)
+        ttk.Scale(btn_frame, from_=-50, to=50, orient="horizontal", variable=self.y_var, command=self._update_offset, length=100).pack(side="left", padx=2)
         ttk.Button(btn_frame, text=translate(UIText.BUTTON_FLIP), command=self._toggle_flip).pack(side="left", padx=2)
         ttk.Button(btn_frame, text=translate(UIText.BUTTON_SKIP), command=self._skip).pack(side="left", padx=2)
         ttk.Button(btn_frame, text=translate(UIText.BUTTON_NEXT), command=self._next).pack(side="left", padx=2)
@@ -919,6 +952,8 @@ class PreviewWindow(tk.Toplevel):
         self.angle_var.set(t.get("rotate", 0.0))
         self.scale_var.set(t.get("scale", 1.0))
         self.flip = t.get("flip", False)
+        self.x_var.set(t.get("offset_x", 0.0))
+        self.y_var.set(t.get("offset_y", 0.0))
         if not self._generate_image(item):
             return
         self._update_image()
@@ -930,6 +965,8 @@ class PreviewWindow(tk.Toplevel):
                 rotate=self.angle_var.get(),
                 flip=self.flip,
                 scale=self.scale_var.get(),
+                offset_x=self.x_var.get(),
+                offset_y=self.y_var.get(),
             )
         except FileNotFoundError:
             if messagebox.askretrycancel(
@@ -957,6 +994,9 @@ class PreviewWindow(tk.Toplevel):
     def _update_angle(self, _value: str) -> None:
         self._apply_transform()
 
+    def _update_offset(self, _value: str) -> None:
+        self._apply_transform()
+
     def _toggle_flip(self) -> None:
         self.flip = not self.flip
         self._apply_transform()
@@ -975,6 +1015,8 @@ class PreviewWindow(tk.Toplevel):
                 self.angle_var.get(),
                 self.scale_var.get(),
                 self.flip,
+                self.x_var.get(),
+                self.y_var.get(),
             )
         self.skip_flag = False
         self.index += 1
@@ -997,6 +1039,11 @@ class SpellPreviewWindow(tk.Toplevel):
         cache: dict,
     ) -> None:
         super().__init__(root)
+        try:
+            icon = tk.PhotoImage(file=IMAGE.PATHS.APP_ICON)
+            self.iconphoto(True, icon)
+        except Exception:
+            pass
         self.title(translate(UIText.SPELL_PREVIEW_TITLE))
         self.configure(bg=root["background"])
         self.spells = spells
@@ -1029,6 +1076,26 @@ class SpellPreviewWindow(tk.Toplevel):
             command=self._update_scale,
             length=150,
         ).pack(side="left", padx=2)
+        self.x_var = tk.DoubleVar(value=0)
+        ttk.Scale(
+            btn_frame,
+            from_=-50,
+            to=50,
+            orient="horizontal",
+            variable=self.x_var,
+            command=self._update_offset,
+            length=100,
+        ).pack(side="left", padx=2)
+        self.y_var = tk.DoubleVar(value=0)
+        ttk.Scale(
+            btn_frame,
+            from_=-50,
+            to=50,
+            orient="horizontal",
+            variable=self.y_var,
+            command=self._update_offset,
+            length=100,
+        ).pack(side="left", padx=2)
         ttk.Button(btn_frame, text=translate(UIText.BUTTON_FLIP), command=self._toggle_flip).pack(side="left", padx=2)
         ttk.Button(btn_frame, text=translate(UIText.BUTTON_SKIP), command=self._skip).pack(side="left", padx=2)
         ttk.Button(btn_frame, text=translate(UIText.BUTTON_NEXT), command=self._next).pack(side="left", padx=2)
@@ -1046,6 +1113,8 @@ class SpellPreviewWindow(tk.Toplevel):
         self.angle_var.set(t.get("rotate", 0.0))
         self.scale_var.set(t.get("scale", 1.0))
         self.flip = t.get("flip", False)
+        self.x_var.set(t.get("offset_x", 0.0))
+        self.y_var.set(t.get("offset_y", 0.0))
         if not self._generate_image(sp):
             return
         self._update_image()
@@ -1057,6 +1126,8 @@ class SpellPreviewWindow(tk.Toplevel):
                 rotate=self.angle_var.get(),
                 flip=self.flip,
                 scale=self.scale_var.get(),
+                offset_x=self.x_var.get(),
+                offset_y=self.y_var.get(),
             )
         except FileNotFoundError:
             if messagebox.askretrycancel(
@@ -1085,6 +1156,9 @@ class SpellPreviewWindow(tk.Toplevel):
     def _update_angle(self, _value: str) -> None:
         self._apply_transform()
 
+    def _update_offset(self, _value: str) -> None:
+        self._apply_transform()
+
     def _toggle_flip(self) -> None:
         self.flip = not self.flip
         self._apply_transform()
@@ -1103,6 +1177,8 @@ class SpellPreviewWindow(tk.Toplevel):
                 self.angle_var.get(),
                 self.scale_var.get(),
                 self.flip,
+                self.x_var.get(),
+                self.y_var.get(),
             )
         self.skip_flag = False
         self.index += 1

--- a/src/helpers/dataHelper.py
+++ b/src/helpers/dataHelper.py
@@ -43,9 +43,22 @@ def saveItemCache(cache: dict[str, JsonItemCache]) -> None:
         dump(cache, file, ensure_ascii=False, indent=4)
 
 
-def updateItemCache(item_id: str, rotate: float, scale: float, flip: bool) -> None:
+def updateItemCache(
+    item_id: str,
+    rotate: float,
+    scale: float,
+    flip: bool,
+    offset_x: float,
+    offset_y: float,
+) -> None:
     cache = loadItemCache()
-    cache[item_id] = {"rotate": rotate, "scale": scale, "flip": flip}
+    cache[item_id] = {
+        "rotate": rotate,
+        "scale": scale,
+        "flip": flip,
+        "offset_x": offset_x,
+        "offset_y": offset_y,
+    }
     saveItemCache(cache)
 
 
@@ -79,7 +92,20 @@ def saveSpellCache(cache: dict[str, JsonItemCache]) -> None:
         dump(cache, file, ensure_ascii=False, indent=4)
 
 
-def updateSpellCache(spell_id: str, rotate: float, scale: float, flip: bool) -> None:
+def updateSpellCache(
+    spell_id: str,
+    rotate: float,
+    scale: float,
+    flip: bool,
+    offset_x: float,
+    offset_y: float,
+) -> None:
     cache = loadSpellCache()
-    cache[spell_id] = {"rotate": rotate, "scale": scale, "flip": flip}
+    cache[spell_id] = {
+        "rotate": rotate,
+        "scale": scale,
+        "flip": flip,
+        "offset_x": offset_x,
+        "offset_y": offset_y,
+    }
     saveSpellCache(cache)


### PR DESCRIPTION
## Summary
- update constants with app icon
- expand item/spell cache to store image offsets
- add translation sliders for item and spell card previews
- modernize UI theme and set Feuerball icon on all windows
- support offset parameters in image card generation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6886238233f8832ab3761be13145ae99