### PR TITLE
Add shortName helper for three-letter skill abbreviations

### DIFF
--- a/src/handlers/imageHandler.py
+++ b/src/handlers/imageHandler.py
@@ -23,7 +23,7 @@ from classes.types import (
     Spell,
     TargetType,
 )
-from helpers.translationHelper import translate
+from helpers.translationHelper import translate, shortName
 from helpers.dataHelper import getWeapons, getArmors, getItems, getSpells
 from helpers.formattingHelper import (
     getMaxFontSize,
@@ -535,7 +535,7 @@ class ImageHandler:
         if spell.savingThrow:
             instructions.append(
                 self._textOp(
-                    str(spell.savingThrow)[:3].upper(),
+                    shortName(spell.savingThrow, True),
                     SPELL.SAVING_THROW,
                     FONT.STATS_PATH,
                     FONT_STYLE.SIZES.STATS,

--- a/src/helpers/translationHelper.py
+++ b/src/helpers/translationHelper.py
@@ -89,6 +89,20 @@ def translate(key: Enum) -> str:
     return str(_translations.get(category, {}).get(key.name, key.value))
 
 
+def shortName(key: Enum, translate_name: bool = False) -> str:
+    """Return the first three letters of ``key`` in uppercase.
+
+    Args:
+        key: Enum value to shorten.
+        translate_name: When ``True`` the translated name is used.
+
+    Returns:
+        Three letter abbreviation of ``key``.
+    """
+    name = translate(key) if translate_name else key.name
+    return name[:3].upper()
+
+
 E = TypeVar("E", bound=Enum)
 
 


### PR DESCRIPTION
## Summary
- add `shortName` helper to centralize first-three-letter abbreviations
- use the helper when rendering spell saving throws in `imageHandler`

## Testing
- `pyright >/tmp/pyright.log && tail -n 20 /tmp/pyright.log`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6887995c7b7c832ab0ff01978253fd7c