### PR TITLE
Skip previews for missing images when printing new cards

### DIFF
--- a/src/handlers/imageHandler.py
+++ b/src/handlers/imageHandler.py
@@ -38,6 +38,7 @@ from helpers.formattingHelper import (
     formatTimedelta,
     formatFloatAsInt,
     formatPriceWithSuffix,
+    wrapText,
 )
 from os.path import join
 from PIL import Image, ImageDraw, ImageFont
@@ -551,9 +552,15 @@ class ImageHandler:
             )
         if spell.components.material:
             if spell.components.material.name:
+                wrapped_name = wrapText(
+                    spell.components.material.name,
+                    FONT.STATS_PATH,
+                    FONT_STYLE.SIZES.STATS,
+                    SPELL.MATERIAL.NAME.SIZE.ABSOLUTE[0],
+                )
                 instructions.append(
                     self._textOp(
-                        spell.components.material.name,
+                        wrapped_name,
                         SPELL.MATERIAL.NAME,
                         FONT.STATS_PATH,
                         FONT_STYLE.SIZES.STATS,
@@ -562,7 +569,7 @@ class ImageHandler:
             if spell.components.material.cost is not None:
                 instructions.append(
                     self._textOp(
-                        formatFloatAsInt(spell.components.material.cost),
+                        formatPriceWithSuffix(spell.components.material.cost),
                         SPELL.MATERIAL.COST,
                         FONT.STATS_PATH,
                         SECONDARY_FONT_STYLE.SIZES.STATS,

--- a/src/handlers/interfaceHandler.py
+++ b/src/handlers/interfaceHandler.py
@@ -1752,8 +1752,22 @@ class InterfaceHandler:
         )
         preview_spells: List[Spell] = []
         skip_missing = get_skip_missing()
+        print_missing = get_print_missing()
         for sp in spells:
-            if show_all or sp.id not in cache:
+            if show_all:
+                preview_spells.append(sp)
+            elif sp.id not in cache:
+                if print_missing:
+                    spell_image = join(IMAGE.PATHS.SPELLS, f"{sp.id}.{IMAGE.FORMAT}")
+                    if not os.path.exists(spell_image):
+                        try:
+                            self.image_handler.createSpellCard(sp)
+                        except FileNotFoundError:
+                            if skip_missing:
+                                self.image_handler.recordMissingSpell(sp.id)
+                            else:
+                                raise
+                        continue
                 preview_spells.append(sp)
             else:
                 t = cache[sp.id]
@@ -1797,8 +1811,22 @@ class InterfaceHandler:
         )
         preview_items: List[Item] = []
         skip_missing = get_skip_missing()
+        print_missing = get_print_missing()
         for item in items:
-            if show_all or item.id not in cache:
+            if show_all:
+                preview_items.append(item)
+            elif item.id not in cache:
+                if print_missing:
+                    asset_path = self.image_handler.getItemAssetPath(item)
+                    if not os.path.exists(asset_path):
+                        try:
+                            self.image_handler.createItemCard(item)
+                        except FileNotFoundError:
+                            if skip_missing:
+                                self.image_handler.recordMissingItem(item.id)
+                            else:
+                                raise
+                        continue
                 preview_items.append(item)
             else:
                 t = cache[item.id]
@@ -1839,8 +1867,22 @@ class InterfaceHandler:
         )
         preview_items: List[SimpleItem] = []
         skip_missing = get_skip_missing()
+        print_missing = get_print_missing()
         for item in items:
-            if show_all or item.id not in cache:
+            if show_all:
+                preview_items.append(item)
+            elif item.id not in cache:
+                if print_missing:
+                    asset_path = self.image_handler.getItemAssetPath(item)
+                    if not os.path.exists(asset_path):
+                        try:
+                            self.image_handler.createItemCard(item)
+                        except FileNotFoundError:
+                            if skip_missing:
+                                self.image_handler.recordMissingItem(item.id)
+                            else:
+                                raise
+                        continue
                 preview_items.append(item)
             else:
                 t = cache[item.id]
@@ -1881,8 +1923,22 @@ class InterfaceHandler:
         )
         preview_items: List[Armor] = []
         skip_missing = get_skip_missing()
+        print_missing = get_print_missing()
         for item in items:
-            if show_all or item.id not in cache:
+            if show_all:
+                preview_items.append(item)
+            elif item.id not in cache:
+                if print_missing:
+                    asset_path = self.image_handler.getItemAssetPath(item)
+                    if not os.path.exists(asset_path):
+                        try:
+                            self.image_handler.createItemCard(item)
+                        except FileNotFoundError:
+                            if skip_missing:
+                                self.image_handler.recordMissingItem(item.id)
+                            else:
+                                raise
+                        continue
                 preview_items.append(item)
             else:
                 t = cache[item.id]

--- a/src/helpers/formattingHelper.py
+++ b/src/helpers/formattingHelper.py
@@ -51,6 +51,25 @@ def getMaxFontSize(
     return size
 
 
+def wrapText(text: str, fontPath: str, maxSize: int, maxWidth: float) -> str:
+    """Insert a line break to maximize font size within the given width."""
+    words = text.split()
+    if len(words) <= 1:
+        return text
+
+    bestText = text
+    bestSize = getMaxFontSize(text, fontPath, maxSize, maxWidth)
+
+    for splitPoint in range(1, len(words)):
+        candidate = " ".join(words[:splitPoint]) + "\n" + " ".join(words[splitPoint:])
+        size = getMaxFontSize(candidate, fontPath, maxSize, maxWidth)
+        if size > bestSize:
+            bestSize = size
+            bestText = candidate
+
+    return bestText
+
+
 def findOptimalAttributeLayout(
     attributes: list[str],
     fixedRows: list[str],


### PR DESCRIPTION
## Summary
- Skip preview windows for new cards whose images are missing when "Print missing images" is enabled
- Apply missing-image checks for spells, weapons, items, and armors so users aren't forced through needless previews
- Format spell material costs with `k`/`M` suffixes (e.g. 1500 → 1.5k)
- Wrap long material component names onto multiple lines to better use available space on spell cards

## Testing
- `python -m pyright`


------
https://chatgpt.com/codex/tasks/task_e_68b9a938132c832a9e8dd4074d6e0cf9